### PR TITLE
Proper handling of TX versions / consensus branch IDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ APPNAME = "Zcash"
 # Application version
 APPVERSION_M=2
 APPVERSION_N=3
-APPVERSION_P=1
+APPVERSION_P=2
 APPVERSION = "$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)"
 
 # Application source files

--- a/include/btchip_context.h
+++ b/include/btchip_context.h
@@ -239,11 +239,11 @@ struct btchip_context_s {
     /* Overwinter */
     unsigned char usingOverwinter;
     unsigned char overwinterSignReady;
-    unsigned char NU5Transaction;
     unsigned char nVersionGroupId[4];
     unsigned char nExpiryHeight[4];
     unsigned char nLockTime[4];
     unsigned char sigHashType[4];
+    unsigned char consensusBranchId[4];
 
     struct {
         unsigned char header_digest[DIGEST_SIZE];
@@ -311,7 +311,7 @@ typedef struct btchip_altcoin_config_s {
     unsigned short p2sh_version;
     unsigned char family;
 #ifdef HAVE_NBGL
-    unsigned char img_raw[1024]; 
+    unsigned char img_raw[1024];
     nbgl_icon_details_t img_nbgl;
 #endif // HAVE_NBGL
     char coinid[14]; // used coind id for message signature prefix

--- a/src/btchip_apdu_get_trusted_input.c
+++ b/src/btchip_apdu_get_trusted_input.c
@@ -49,7 +49,6 @@ unsigned short btchip_apdu_get_trusted_input() {
         btchip_context_D.transactionHashOption = TRANSACTION_HASH_FULL;
         btchip_context_D.usingSegwit = 0;
         btchip_context_D.usingOverwinter = 0;
-        btchip_context_D.NU5Transaction = 0;
     } else if (G_io_apdu_buffer[ISO_OFFSET_P1] != GET_TRUSTED_INPUT_P1_NEXT) {
         return BTCHIP_SW_INCORRECT_P1_P2;
     }
@@ -84,7 +83,7 @@ unsigned short btchip_apdu_get_trusted_input() {
         G_io_apdu_buffer[0] = MAGIC_TRUSTED_INPUT;
         G_io_apdu_buffer[1] = 0x00;
 
-        if (!btchip_context_D.NU5Transaction) {
+        if (TX_VERSION != 5) {
             cx_hash_sha256(G_io_apdu_buffer + TRUSTED_INPUT_SIZE, 32, G_io_apdu_buffer + 4, 32);
         } else {
             memmove(G_io_apdu_buffer + 4, G_io_apdu_buffer + TRUSTED_INPUT_SIZE, 32);

--- a/src/btchip_apdu_hash_input_finalize_full.c
+++ b/src/btchip_apdu_hash_input_finalize_full.c
@@ -412,7 +412,7 @@ return_OK:
                 }
             }
             PRINTF("hashOutputs\n%.*H\n",32,btchip_context_D.segwit.cache.hashedOutputs);
-            if (btchip_context_D.NU5Transaction) {
+            if (TX_VERSION == 5) {
                 memcpy(btchip_context_D.nu5_ctx.prevouts_sig_digest, btchip_context_D.segwit.cache.hashedPrevouts, DIGEST_SIZE);
                 memcpy(btchip_context_D.nu5_ctx.sequence_sig_digest, btchip_context_D.segwit.cache.hashedSequence, DIGEST_SIZE);
                 memcpy(btchip_context_D.nu5_ctx.outputs_sig_digest, btchip_context_D.segwit.cache.hashedOutputs, DIGEST_SIZE);

--- a/src/btchip_rom_variables.c
+++ b/src/btchip_rom_variables.c
@@ -52,9 +52,6 @@ unsigned char const OVERWINTER_PARAM_OUTPUTS[16] = { 'Z', 'c', 'a', 's', 'h', 'O
 unsigned char const OVERWINTER_PARAM_SIGHASH[16] = { 'Z', 'c', 'a', 's', 'h', 'S', 'i', 'g', 'H', 'a', 's', 'h', 0, 0, 0, 0 };
 unsigned char const OVERWINTER_NO_JOINSPLITS[32] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
-unsigned char const NU5_GROUP_ID[4] = {0xB4, 0xD0, 0xD6, 0xC2};
-unsigned char const NU6_GROUP_ID[4] = {0x55, 0x10, 0xE7, 0xC8};
-
 unsigned char const NU5_PARAM_TXID[16] = { 'Z', 'c', 'a', 's', 'h', 'T', 'x', 'H', 'a', 's', 'h', '_', 0, 0, 0, 0};
 unsigned char const NU5_PARAM_HEADERS[16] = { 'Z', 'T', 'x', 'I', 'd', 'H', 'e', 'a', 'd', 'e', 'r', 's', 'H', 'a', 's', 'h' };
 unsigned char const NU5_PARAM_TRANSPA[16] = { 'Z', 'T', 'x', 'I', 'd', 'T', 'r', 'a', 'n', 's', 'p', 'a', 'H', 'a', 's', 'h' };

--- a/src/btchip_rom_variables.h
+++ b/src/btchip_rom_variables.h
@@ -34,8 +34,6 @@ extern unsigned char const OVERWINTER_PARAM_OUTPUTS[16];
 extern unsigned char const OVERWINTER_PARAM_SIGHASH[16];
 extern unsigned char const OVERWINTER_NO_JOINSPLITS[32];
 
-extern unsigned char const NU5_GROUP_ID[4];
-extern unsigned char const NU6_GROUP_ID[4];
 extern unsigned char const NU5_PARAM_TXID[16];
 extern unsigned char const NU5_PARAM_HEADERS[16];
 extern unsigned char const NU5_PARAM_TRANSPA[16];

--- a/src/btchip_transaction.h
+++ b/src/btchip_transaction.h
@@ -31,6 +31,11 @@
 #define TRUSTED_INPUT_SIZE   48
 #define TRUSTED_INPUT_TOTAL_SIZE (TRUSTED_INPUT_SIZE + 8)
 
+#define OVERWINTER_FLAG (1 << 31)
+
+#define TX_IS_OVERWINTER    (btchip_read_u32(btchip_context_D.transactionVersion, false, false) & OVERWINTER_FLAG)
+#define TX_VERSION          (btchip_read_u32(btchip_context_D.transactionVersion, false, false) ^ OVERWINTER_FLAG)
+
 void transaction_parse(unsigned char parseMode);
 
 // target = a + b

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -20,7 +20,7 @@ def test_NU5_signature(cmd, transport):
     SIG_LEN = 142
     EXPECTED_SIG = "304402202b22627d88f9ecebf2ab586ffa970232cddad6eabb3289fa1359b2bc9f5554bc02207cfba5db7c01b89c5d540dcb1ada67d485ab1638c2151eaa78b4d368059c007801"
 
-    sw, _ = transport.exchange_raw("e04200000d00000000050000800a27a72601")
+    sw, _ = transport.exchange_raw("e04200001100000000050000800a27a726b4d0d6c201")
     assert sw == 0x9000
     sw, _ = transport.exchange_raw("e04280002598cd6cd9559cd98109ad0622f899bc38805f11648e4f985ebe344b8238f87b13010000006b")
     assert sw == 0x9000
@@ -48,7 +48,7 @@ def test_NU5_signature(cmd, transport):
     assert len(key) == KEY_LEN
     key = key[4:70]
 
-    sw, _ = transport.exchange_raw("e044000509050000800a27a72601")
+    sw, _ = transport.exchange_raw("e04400050d050000800a27a726b4d0d6c201")
     assert sw == 0x9000
     sw, _ = transport.exchange_raw("e04480053b0138" + txid + "19")
     assert sw == 0x9000
@@ -60,7 +60,7 @@ def test_NU5_signature(cmd, transport):
     assert sw == 0x9000
     sw, _ = transport.exchange_raw("e04800000b0000000000000100000000")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e044008009050000800a27a72601")
+    sw, _ = transport.exchange_raw("e04400800d050000800a27a726b4d0d6c201")
     assert sw == 0x9000
     sw, _ = transport.exchange_raw("e04480803b0138" + txid + "19")
     assert sw == 0x9000
@@ -84,7 +84,7 @@ def test_NU5_signature_mult_inputs(cmd, transport):
             "3145022100a4cc9821cf530a179cf2bcf767644ff62e0b0cf79a5701101914be6c215b0bcc02202d2ac5ef2289caa7fafc94ce38b2e46baf5987b86193e0251f4cf2585c174ccd01"
             ]
 
-    sw, _ = transport.exchange_raw("e04200000d00000000050000800a27a72601")
+    sw, _ = transport.exchange_raw("e04200001100000000050000800a27a726b4d0d6c201")
     assert sw == 0x9000
     sw, _ = transport.exchange_raw("e0428000257acad6b8eec3158ecee566c0f08ff721d94d44b0cf66ee220ad4f9d1692d2ab5000000006a")
     assert sw == 0x9000
@@ -104,7 +104,7 @@ def test_NU5_signature_mult_inputs(cmd, transport):
     assert sw == 0x9000
     assert len(txid1) == TXID_LEN
 
-    sw, _ = transport.exchange_raw("e04200000d00000000050000800a27a72601")
+    sw, _ = transport.exchange_raw("e04200001100000000050000800a27a726b4d0d6c201")
     assert sw == 0x9000
     sw, _ = transport.exchange_raw("e04280002558b3391f27adce90eb8e0ae7e082449204c6d5c3843378e538c8770928d49ca3000000006b")
     assert sw == 0x9000
@@ -124,7 +124,7 @@ def test_NU5_signature_mult_inputs(cmd, transport):
     assert sw == 0x9000
     assert len(txid2) == TXID_LEN
 
-    sw, _ = transport.exchange_raw("e04200000d00000000050000800a27a72601")
+    sw, _ = transport.exchange_raw("e04200001100000000050000800a27a726b4d0d6c201")
     assert sw == 0x9000
     sw, _ = transport.exchange_raw("e042800025b5026481bfd3417f4a179e2094a944a60aaad5b2726544ca1a2c920fb65c9401000000006b")
     assert sw == 0x9000
@@ -163,7 +163,7 @@ def test_NU5_signature_mult_inputs(cmd, transport):
     assert len(key3) == KEY_LEN
     key3 = key3[4:70]
 
-    sw, _ = transport.exchange_raw("e044000509050000800a27a72603")
+    sw, _ = transport.exchange_raw("e04400050d050000800a27a726b4d0d6c203")
     assert sw == 0x9000
     sw, _ = transport.exchange_raw("e04480803b0138" + txid1 + "19")
     assert sw == 0x9000
@@ -181,7 +181,7 @@ def test_NU5_signature_mult_inputs(cmd, transport):
     assert sw == 0x9000
     sw, _ = transport.exchange_raw("e04800000b0000000000000100000000")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e044008009050000800a27a72601")
+    sw, _ = transport.exchange_raw("e04400800d050000800a27a726b4d0d6c201")
     assert sw == 0x9000
     sw, _ = transport.exchange_raw("e04480803b0138" + txid1 + "19")
     assert sw == 0x9000
@@ -189,7 +189,7 @@ def test_NU5_signature_mult_inputs(cmd, transport):
     assert sw == 0x9000
     sw, sig1 = transport.exchange_raw("e04800001f058000002c8000008580000002000000000000000200000000000100000000")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e044008009050000800a27a72601")
+    sw, _ = transport.exchange_raw("e04400800d050000800a27a726b4d0d6c201")
     assert sw == 0x9000
     sw, _ = transport.exchange_raw("e04480803b0138" + txid2 + "19")
     assert sw == 0x9000
@@ -197,7 +197,7 @@ def test_NU5_signature_mult_inputs(cmd, transport):
     assert sw == 0x9000
     sw, sig2 = transport.exchange_raw("e04800001f058000002c8000008580000002000000000000000200000000000100000000")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e044008009050000800a27a72601")
+    sw, _ = transport.exchange_raw("e04400800d050000800a27a726b4d0d6c201")
     assert sw == 0x9000
     sw, _ = transport.exchange_raw("e04480803b0138" + txid3 + "19")
     assert sw == 0x9000
@@ -215,56 +215,56 @@ def test_NU5_signature_mult_outputs(cmd, transport):
     KEY_LEN = 268
     SIG = "3045022100867fdc2d2873b15bc19a42df288a257aff08ba74b9e2eefd1245e69b05a181b302200b876a40a9339b8b8333c332319dbe5329af363628e0fd4847b281719986dc7b01"
 
-    sw, _ = transport.exchange_raw("e04200000d00000000050000800a27a72601 ")
+    sw, _ = transport.exchange_raw("e04200001100000000050000800a27a726b4d0d6c201")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e0428000257acad6b8eec3158ecee566c0f08ff721d94d44b0cf66ee220ad4f9d1692d2ab5000000006a ")
+    sw, _ = transport.exchange_raw("e0428000257acad6b8eec3158ecee566c0f08ff721d94d44b0cf66ee220ad4f9d1692d2ab5000000006a")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e04280003247304402200d6900cafe4189b9dfebaa965584f39e07cf6086ed5a97c84a5a76035dddcf7302206263c8b7202227e0ab33dd ")
+    sw, _ = transport.exchange_raw("e04280003247304402200d6900cafe4189b9dfebaa965584f39e07cf6086ed5a97c84a5a76035dddcf7302206263c8b7202227e0ab33dd")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e042800032263e04f7a4384d34daa9279bfdebb03bf4b62123590121023e7c3ab4b4a42466f2c72c79afd426a0714fed74f884cd11abb4 ")
+    sw, _ = transport.exchange_raw("e042800032263e04f7a4384d34daa9279bfdebb03bf4b62123590121023e7c3ab4b4a42466f2c72c79afd426a0714fed74f884cd11abb4")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e04280000ad76a72fa4a6900000000 ")
+    sw, _ = transport.exchange_raw("e04280000ad76a72fa4a6900000000")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e04280000101 ")
+    sw, _ = transport.exchange_raw("e04280000101")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e042800022957edd04000000001976a914effcdc2e850d1c35fa25029ddbfad5928c9d702f88ac ")
+    sw, _ = transport.exchange_raw("e042800022957edd04000000001976a914effcdc2e850d1c35fa25029ddbfad5928c9d702f88ac")
     assert sw == 0x9000
-    
-    sw, txid1 = transport.exchange_raw("e042800009000000000400000000 ")
+
+    sw, txid1 = transport.exchange_raw("e042800009000000000400000000")
     txid1 = txid1.hex()
     assert sw == 0x9000
     assert len(txid1) == TXID_LEN
-    
-    sw, key = transport.exchange_raw("e040000015058000002c80000085800000020000000000000002 ")
+
+    sw, key = transport.exchange_raw("e040000015058000002c80000085800000020000000000000002")
     key = key.hex()
     assert sw == 0x9000
     assert len(key) == KEY_LEN
     key = key[4:70]
-    
-    sw, _ = transport.exchange_raw("e044000509050000800a27a72601 ")
+
+    sw, _ = transport.exchange_raw("e04400050d050000800a27a726b4d0d6c201")
     assert sw == 0x9000
     sw, _ = transport.exchange_raw("e04480053b0138" + txid1 + "19")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e04480801d76a914effcdc2e850d1c35fa25029ddbfad5928c9d702f88ac00000000 ")
+    sw, _ = transport.exchange_raw("e04480801d76a914effcdc2e850d1c35fa25029ddbfad5928c9d702f88ac00000000")
     assert sw == 0x9000
-    
-    sw, _ = transport.exchange_raw("e04480050400000000 ")
+
+    sw, _ = transport.exchange_raw("e04480050400000000")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e04aff0015058000002c80000085800000020000000100000000 ")
+    sw, _ = transport.exchange_raw("e04aff0015058000002c80000085800000020000000100000000")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e04a00003202005a6202000000001976a9147d352e6e9a926965c677327443d86cb0bdf8b1e988acc11b7b02000000001976a91456464d ")
+    sw, _ = transport.exchange_raw("e04a00003202005a6202000000001976a9147d352e6e9a926965c677327443d86cb0bdf8b1e988acc11b7b02000000001976a91456464d")
     assert sw == 0x009000
-    sw, _ = transport.exchange_raw("e04a800013f31771790b77502f55895a396a64e74da588ac ")
+    sw, _ = transport.exchange_raw("e04a800013f31771790b77502f55895a396a64e74da588ac")
     assert sw == 0x00009000
-    sw, _ = transport.exchange_raw("e04800000b0000000000000100000000 ")
+    sw, _ = transport.exchange_raw("e04800000b0000000000000100000000")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e044008009050000800a27a72601 ")
+    sw, _ = transport.exchange_raw("e04400800d050000800a27a726b4d0d6c201")
     assert sw == 0x9000
     sw, _ = transport.exchange_raw("e04480803b0138" + txid1 + "19")
     assert sw == 0x9000
-    sw, _ = transport.exchange_raw("e04480801d76a914effcdc2e850d1c35fa25029ddbfad5928c9d702f88ac00000000 ")
+    sw, _ = transport.exchange_raw("e04480801d76a914effcdc2e850d1c35fa25029ddbfad5928c9d702f88ac00000000")
     assert sw == 0x9000
-    sw, sig = transport.exchange_raw("e04800001f058000002c8000008580000002000000000000000200000000000100000000 ")
+    sw, sig = transport.exchange_raw("e04800001f058000002c8000008580000002000000000000000200000000000100000000")
     assert sw == 0x9000
 
     assert sig.hex() == SIG


### PR DESCRIPTION
Yet another breaking change.

* removes all hardcoded consensus branch IDs
* proper handling of tx version / consensus branch ID (by receiving the consensus branch ID from the software wallet)

Static analysis is :red_circle:  for Flex & Stax because it still uses some deprecated NBGL functions, but this was not the point of this PR and will have to be fixed later.